### PR TITLE
Add comprehensive README documentation for all scripts

### DIFF
--- a/Database_Scripts/MySQL/README.md
+++ b/Database_Scripts/MySQL/README.md
@@ -1,0 +1,17 @@
+# MySQL
+
+Este directorio contiene utilidades interactivas para gestionar copias de seguridad de instancias MySQL/MariaDB.
+
+## Scripts
+
+### `dumpmysql.sh`
+- **Funcionalidad:** asistente interactivo en Bash que valida credenciales con `mysql_config_editor`, comprueba el estado del servicio y permite generar copias de seguridad puntuales o masivas. Puede crear un respaldo único, un volcado consolidado de todas las bases de datos o dumps individuales por base, y registra toda la actividad en `~/DumpMySQL.log`.
+- **Precisión y alcance:** utiliza directamente `mysqldump`, por lo que la fiabilidad del respaldo depende del estado del servidor y de los permisos del usuario. Valida la existencia del usuario, confirma rutas de salida y ofrece compresión opcional (`tar`). Supone entornos tipo Debian/Ubuntu con `service mysql` disponible.
+- **Complejidad:** media. El script orquesta múltiples flujos, maneja errores comunes y automatiza tareas tediosas, pero no implementa programación concurrente ni comprobaciones avanzadas de integridad.
+- **Manual de uso:**
+  1. Ejecutar como un usuario con acceso administrativo sobre MySQL (`bash dumpmysql.sh`).
+  2. Iniciar el servicio cuando se solicite si está detenido.
+  3. Introducir el usuario MySQL; la contraseña se registra mediante `mysql_config_editor` sin exponerla en texto plano.
+  4. Elegir una opción del menú (dump individual, completo en un único archivo, dumps separados o listado de bases de datos).
+  5. Especificar la carpeta de salida (el script la crea si no existe) y si se desea comprimir el resultado.
+  6. Supervisar el progreso en pantalla y, si es necesario, revisar el fichero de log del home para diagnosticar fallos.

--- a/Deployment_Environments/CyberLab/scripts/README.md
+++ b/Deployment_Environments/CyberLab/scripts/README.md
@@ -1,0 +1,22 @@
+# scripts
+
+Utilidades incluidas en la imagen CyberLab para mantenimiento y actualización del entorno.
+
+## Scripts
+
+### `backup-data.sh`
+- **Funcionalidad:** genera archivos `tar.gz` diarios con el contenido de `/home/security/{workspace,reports,scripts}`.
+- **Precisión:** limpia temporalmente los datos en un directorio seguro y protege los respaldos con permisos `600`. Solo copia scripts personalizados (no `.sh`).
+- **Complejidad:** baja.
+- **Manual de uso:** ejecutar como usuario `security`, revisar/ajustar rutas y programar con cron si se desea automatizar. Los respaldos se guardan en `/home/security/data/backups`.
+
+### `setup-tools.sh`
+- **Funcionalidad:** clona y actualiza una colección de herramientas de seguridad (SecLists, PEASS, AutoRecon, etc.), instala dependencias Python y descarga wordlists.
+- **Precisión:** requiere acceso a Internet y `git`. No maneja fallos específicos de cada repositorio.
+- **Complejidad:** media por la cantidad de repositorios gestionados.
+- **Manual de uso:** ejecutar tras construir la imagen o periódicamente. Ajustar la lista `tools`/`forensic_tools` según necesidades.
+
+### `update-system.sh`
+- **Funcionalidad:** actualiza paquetes APT, actualiza módulos Python y vuelve a ejecutar `setup-tools.sh`.
+- **Precisión:** usa `sudo` y asume credenciales configuradas. Puede tardar dependiendo del número de herramientas instaladas.
+- **Manual de uso:** programar tras despliegues o como tarea de mantenimiento. Revisar la salida para detectar paquetes que requieran intervención manual.

--- a/Deployment_Environments/Ubuntu-Server/README.md
+++ b/Deployment_Environments/Ubuntu-Server/README.md
@@ -1,0 +1,17 @@
+# Ubuntu-Server
+
+Definición de contenedor Ubuntu 24.04 preconfigurado para labores administrativas.
+
+## Archivos
+
+### `Dockerfile`
+- **Funcionalidad:** construye una imagen con localización `es_ES.UTF-8`, zona horaria Madrid y un amplio catálogo de utilidades (diagnóstico de red, seguridad, edición, monitoreo). Evita paquetes problemáticos (`pcp`), configura `policy-rc.d` y prepara un entorno listo para tareas de bastionado o laboratorio.
+- **Complejidad:** alta; instala decenas de paquetes y aplica varias capas de configuración.
+- **Manual de uso:**
+  1. Ajustar paquetes según las necesidades (por ejemplo, eliminar `masscan` si no se requiere).
+  2. Construir con `docker build -t ubuntu-admin .`.
+  3. Lanzar con `docker run -it --rm ubuntu-admin` y montar volúmenes si se necesitan scripts persistentes.
+
+### `docker-compose.yml`
+- **Funcionalidad:** crea un servicio único basado en la imagen construida, expone el puerto SSH (`2222:22`) y monta volúmenes para persistir `/home` y archivos de configuración.
+- **Manual de uso:** ejecutar `docker compose up -d` tras compilar la imagen, actualizar las rutas de volúmenes y definir contraseñas/llaves en la configuración de `openssh-server` dentro del contenedor.

--- a/Deployment_Scripts/Docker/README.md
+++ b/Deployment_Scripts/Docker/README.md
@@ -1,0 +1,10 @@
+# Docker
+
+### `DockerInstall.sh`
+- **Funcionalidad:** instala Docker Engine y complementos (`docker-ce`, `docker-compose-plugin`, `buildx`), elimina versiones previas, configura el repositorio oficial y agrega al usuario al grupo `docker`. Mantiene un log en `/tmp/docker_install_*.log`.
+- **Precisión:** diseñado para Ubuntu/Debian. Verifica arquitectura soportada y requiere conexión a Internet.
+- **Complejidad:** media.
+- **Manual de uso:**
+  1. Ejecutar como root (`sudo ./DockerInstall.sh`).
+  2. Revisar el log si ocurre algún error.
+  3. Cerrar sesión para aplicar la pertenencia al grupo `docker`.

--- a/Deployment_Scripts/Kubernetes/README.md
+++ b/Deployment_Scripts/Kubernetes/README.md
@@ -1,0 +1,17 @@
+# Kubernetes
+
+Recursos para automatizar la instalación de Kubernetes "The Hard Way".
+
+## Archivos
+
+### `kthw_autoinstall.sh`
+- **Funcionalidad:** ejecuta todo el procedimiento "Kubernetes The Hard Way" sobre Debian 12: recopila parámetros, distribuye claves SSH, configura `/etc/hosts`, descarga binarios, genera certificados, instala control plane y workers, y aplica configuraciones de red.
+- **Precisión:** requiere acceso root al jumpbox y a los nodos remotos, además de herramientas como `sshpass`, `curl`, `jq`. Las versiones de Kubernetes y dependencias están fijadas en el script.
+- **Complejidad:** muy alta.
+- **Manual de uso:**
+  1. Ejecutar como root en la máquina de salto (`sudo ./kthw_autoinstall.sh`).
+  2. Proporcionar dominio, IPs y credenciales cuando el script lo solicite.
+  3. Verificar la salida final y utilizar `kubectl` desde el directorio generado.
+
+### `The Hard Way Guide.md`
+- **Funcionalidad:** guía escrita con el procedimiento detallado, útil para entender cada paso automatizado por el script.

--- a/Deployment_Scripts/Moodle/README.md
+++ b/Deployment_Scripts/Moodle/README.md
@@ -1,0 +1,10 @@
+# Moodle
+
+### `install_moodle.sh`
+- **Funcionalidad:** instala Moodle sobre Ubuntu/Debian: actualiza paquetes, despliega LAMP stack con PHP 8.1 y extensiones necesarias, clona Moodle desde Git y prepara permisos.
+- **Precisión:** usa credenciales MySQL estáticas que deben cambiarse en producción. Depende de `git` y `mysql_secure_installation` interactivo.
+- **Complejidad:** media.
+- **Manual de uso:**
+  1. Ejecutar como usuario con sudo (`sudo ./install_moodle.sh`).
+  2. Durante `mysql_secure_installation` establecer contraseña root y políticas.
+  3. Completar la instalación desde el navegador apuntando a `http://<host>/moodle`.

--- a/Deployment_Scripts/Nagios/PHP Web Monitor SNMP/README.md
+++ b/Deployment_Scripts/Nagios/PHP Web Monitor SNMP/README.md
@@ -1,0 +1,6 @@
+# PHP Web Monitor SNMP
+
+- **`index.php`**
+  - **Funcionalidad:** carga las definiciones de host de Nagios, ejecuta pings en paralelo y muestra estado/latencia desde una interfaz web con refresco dinámico (via AJAX).
+  - **Requisitos:** PHP con acceso a funciones `proc_open`, permisos para leer `/usr/local/nagios/etc/objects` y ejecutar `ping`.
+  - **Manual:** desplegar en un servidor web (por ejemplo, `/usr/local/nagios/share/`), asegurarse de que PHP tenga permisos adecuados y acceder mediante navegador para visualizar el estado de los hosts.

--- a/Deployment_Scripts/Nagios/README.md
+++ b/Deployment_Scripts/Nagios/README.md
@@ -1,0 +1,30 @@
+# Nagios Deployment Scripts
+
+Automatizaciones para instalar Nagios Core y utilidades relacionadas.
+
+## Scripts
+
+### `install_nagios.sh`
+- **Funcionalidad:** descarga Nagios Core 4.4.14 y plugins 2.4.6, crea usuario/grupos y compila una instancia en un directorio personalizado.
+- **Precisión:** requiere Ubuntu/Debian, Apache2 y PHP 7.4. Pide una contraseña para `nagiosadmin` durante la instalación.
+- **Complejidad:** media.
+- **Manual:** ejecutar como sudo, introducir nombre de instancia y seguir prompts.
+
+### `install_nagios_v2.sh`
+- **Funcionalidad:** versión mejorada que detecta automáticamente la IP de acceso, obtiene la versión más reciente desde GitHub y guía al operador con mensajes coloreados.
+- **Precisión:** idem anterior pero con más validaciones. Usa `curl` para descubrir versiones.
+- **Complejidad:** media-alta.
+- **Manual:** `sudo ./install_nagios_v2.sh`, responder preguntas y anotar la URL sugerida.
+
+### `install_nagios_v3.sh`
+- **Funcionalidad:** agrega logging exhaustivo en `/tmp/nagios_install_*.log`, manejo de errores robusto y reutiliza funciones (`run_command`, `log_message`). Descarga versiones recientes dinámicamente.
+- **Precisión:** mismo entorno base que v2, actualiza dependencias a PHP 8.3.
+- **Complejidad:** alta.
+- **Manual:** ejecutar como sudo, revisar el log en caso de fallo y seguir las instrucciones finales para acceder a la interfaz.
+
+## Subdirectorios
+
+### `PHP Web Monitor SNMP`
+- **Archivo:** `index.php`.
+  - **Funcionalidad:** panel PHP que lee configuraciones de Nagios, ejecuta `ping` concurrentemente y muestra estado/latencia de hosts.
+  - **Manual:** copiar a un servidor web con permisos para leer `/usr/local/nagios/etc/objects`, ajustar rutas según la instalación y acceder vía navegador.

--- a/Deployment_Scripts/NextCloud/README.md
+++ b/Deployment_Scripts/NextCloud/README.md
@@ -1,0 +1,10 @@
+# Nextcloud
+
+### `install_nextcloud.sh`
+- **Funcionalidad:** despliega Nextcloud en Ubuntu/Debian instalando Apache, MariaDB y PHP con las extensiones necesarias, crea base de datos/usuario y configura un `VirtualHost` básico.
+- **Precisión:** usa credenciales codificadas (`nextclouduser`/`T3mp0r4l`) que deben cambiarse. `mysql_secure_installation` solicita entrada manual.
+- **Complejidad:** media.
+- **Manual de uso:**
+  1. Ejecutar como usuario con sudo (`sudo ./install_nextcloud.sh`).
+  2. Configurar SSL y dominio en `/etc/apache2/sites-available/nextcloud.conf` según el entorno.
+  3. Acceder vía navegador para completar el asistente web de Nextcloud.

--- a/Deployment_Scripts/Nginx/README.md
+++ b/Deployment_Scripts/Nginx/README.md
@@ -1,0 +1,14 @@
+# Nginx
+
+Scripts para preparar un contenedor Nginx con persistencia local.
+
+## Archivos
+
+### `docker_nginx.sh`
+- **Funcionalidad:** crea estructuras de directorios (`nginx/share`, `nginx/etc`, `nginx/www`, `nginx/ssl`), copia la configuración por defecto desde un contenedor temporal y genera un `docker-compose.yml` listo para usar.
+- **Precisión:** requiere Docker y Docker Compose plugin. El script detiene y elimina el contenedor temporal `tmp-nginx` tras extraer los archivos.
+- **Manual:** ejecutar `./docker_nginx.sh`, editar los archivos en los directorios montados y reiniciar con `docker compose up -d`.
+
+### `docker-compose.yml`
+- **Funcionalidad:** versión mínima que monta configuraciones y certificados desde el host.
+- **Manual:** colocar certificados en `./ssl`, configuración en `./nginx/etc`, luego `docker compose up -d`.

--- a/Deployment_Scripts/Prometheus/README.md
+++ b/Deployment_Scripts/Prometheus/README.md
@@ -1,0 +1,15 @@
+# Prometheus
+
+Scripts para desplegar Prometheus y Node Exporter en servidores Debian/Ubuntu.
+
+## `Install_prometheus.sh`
+- **Funcionalidad:** instala Prometheus 3.2.1, Blackbox Exporter y Node Exporter, crea usuarios de servicio, configura directorios, genera `prometheus.yml` básico y crea unidades systemd.
+- **Precisión:** requiere conexión a Internet y privilegios root. Las URLs de descarga apuntan a GitHub; actualice versiones si es necesario.
+- **Complejidad:** alta.
+- **Manual:** `sudo ./Install_prometheus.sh` y revisar `/etc/prometheus/prometheus.yml` para añadir jobs adicionales.
+
+## `install_node_exporter.sh`
+- **Funcionalidad:** descarga un binario hospedado internamente (`http://10.7.220.15:8000/...`), crea usuario/grupo `node_exporter`, instala el servicio systemd y opcionalmente abre el puerto en UFW.
+- **Precisión:** actualice la URL antes de usarlo en otros entornos. Escucha por defecto en el puerto 9200 (se puede sobrescribir con `PORT=9100 ./install_node_exporter.sh`).
+- **Complejidad:** media.
+- **Manual:** ejecutar como root y comprobar acceso en `http://<host>:9200/metrics`.

--- a/Deployment_Scripts/SELinux/README.md
+++ b/Deployment_Scripts/SELinux/README.md
@@ -1,0 +1,7 @@
+# SELinux
+
+### `fix_selinux_logs.sh`
+- **Funcionalidad:** corrige contextos SELinux de directorios de logs en sistemas RHEL/CentOS: elimina reglas erróneas con `semanage`, ejecuta `restorecon` sobre rutas críticas y crea un log de ejecución.
+- **Precisión:** requiere utilidades `semanage`, `restorecon`, `ausearch`. El script valida su presencia e informa cómo instalarlas si faltan.
+- **Complejidad:** media.
+- **Manual de uso:** ejecutar como root (`sudo ./fix_selinux_logs.sh`), revisar el log generado en `/tmp/selinux_log_fix_*.log` y verificar que los servicios puedan escribir en `/var/log` sin alertas de AVC.

--- a/Deployment_Scripts/Wordpress/README.md
+++ b/Deployment_Scripts/Wordpress/README.md
@@ -1,0 +1,10 @@
+# WordPress
+
+### `Wordpress_install.sh`
+- **Funcionalidad:** automatiza la instalación de WordPress en Ubuntu 22.04 configurando Apache, MySQL, PHP y creando un `VirtualHost`. Genera claves de seguridad y ajusta permisos.
+- **Precisión:** credenciales (`root_password`, `db_password`) deben cambiarse. Utiliza `curl` para obtener salts y no activa HTTPS por defecto.
+- **Complejidad:** media.
+- **Manual de uso:**
+  1. Editar las variables al inicio del script.
+  2. Ejecutar como usuario con sudo (`sudo ./Wordpress_install.sh`).
+  3. Completar el asistente web en `http://<host>/`.

--- a/Deployment_Scripts/firefox/README.md
+++ b/Deployment_Scripts/firefox/README.md
@@ -1,0 +1,7 @@
+# Firefox
+
+### `Firefox_manual_install.sh`
+- **Funcionalidad:** descarga la última versión de Firefox en español, la instala en `/opt/firefox` y crea un acceso directo `.desktop` en `/usr/share/applications`.
+- **Precisión:** sobrescribe cualquier instalación previa en `/opt/firefox`. Requiere conexión a Internet y permisos root.
+- **Complejidad:** baja.
+- **Manual:** ejecutar `sudo ./Firefox_manual_install.sh` y lanzar Firefox desde el menú del sistema.

--- a/Logging_Tools/Audit/README.md
+++ b/Logging_Tools/Audit/README.md
@@ -1,0 +1,14 @@
+# Audit Logging Tools
+
+Herramientas de análisis para los logs de `auditd`.
+
+## Scripts
+
+### `audit_log_analizer.py`
+- **Funcionalidad:** parser interactivo que utiliza expresiones regulares para extraer campos clave (`type`, `timestamp`, `pid`, `uid`, `exe`, etc.) de archivos `audit.log*`. Permite filtrar por tipo de evento, usuario, IP, resultado y múltiples parámetros adicionales.
+- **Precisión:** requiere ejecutarse como root para leer `/var/log/audit/*`. Maneja errores de permisos y valida los argumentos; usa `glob` para combinar archivos rotados.
+- **Complejidad:** media; combina parsing manual, filtro condicional y una clase de `ArgumentParser` personalizada.
+- **Manual de uso:**
+  1. Ejecutar `sudo python3 audit_log_analizer.py --help` para consultar las opciones.
+  2. Aplicar filtros como `--type USER_LOGIN --result success` o `--user root`.
+  3. Revisar la salida estructurada en consola o redirigirla a un archivo para posteriores análisis.

--- a/Network_Scripts/Network/README.md
+++ b/Network_Scripts/Network/README.md
@@ -1,0 +1,7 @@
+# Network
+
+### `interfaces_generator.sh`
+- **Funcionalidad:** inspecciona interfaces físicas y VLAN existentes, calcula máscaras a partir de prefijos CIDR y genera `/etc/network/interfaces` para sistemas Debian.
+- **Precisión:** utiliza comandos `ip` para detectar direcciones y rutas. Sobrescribe el archivo existente; realizar copia de seguridad antes de ejecutarlo.
+- **Complejidad:** media.
+- **Manual:** ejecutar como root (`sudo ./interfaces_generator.sh`) y verificar el resultado en `/etc/network/interfaces` antes de reiniciar la red.

--- a/Operating_System_Configuration/Linux/Kali/README.md
+++ b/Operating_System_Configuration/Linux/Kali/README.md
@@ -1,0 +1,8 @@
+# Kali
+
+Archivos de configuración personalizados para entornos Kali Linux.
+
+- `.zshrc`: configuración del shell Zsh con alias y ajustes orientados a pentesting.
+- `.zsh_functions`: funciones adicionales utilizadas por el perfil (`update`, atajos de recon, etc.).
+
+**Manual:** copiar estos archivos al directorio home del usuario deseado (`cp .zshrc ~/.zshrc`) y recargar la sesión para aplicar los cambios.

--- a/Operating_System_Configuration/Linux/OpenLDAP/README.md
+++ b/Operating_System_Configuration/Linux/OpenLDAP/README.md
@@ -1,0 +1,10 @@
+# OpenLDAP
+
+Asistente para generar entradas LDIF.
+
+## Script
+### `openldap_configure_wizard.sh`
+- **Funcionalidad:** crea archivos `usuario.ldif`, `grupos.ldif` y `unidadesorganizativas.ldif` pidiendo datos por consola y aplicando hashing de contraseñas mediante `slappasswd`.
+- **Precisión:** asume que `slappasswd` está disponible y que los DN siguen el formato `dc=ejemplo,dc=com`. Separa el dominio en dos componentes (`dc1`, `dc2`).
+- **Complejidad:** media; combina menús, bucles y cat heredocs.
+- **Manual de uso:** ejecutar el script, elegir la acción y proporcionar los parámetros solicitados. Los archivos se guardan en `$HOME/LDAP` listos para importarse con `ldapadd -x -D "cn=admin,dc=..." -W -f archivo.ldif`.

--- a/Operating_System_Configuration/Linux/README.md
+++ b/Operating_System_Configuration/Linux/README.md
@@ -1,0 +1,30 @@
+# Linux
+
+Scripts y configuraciones para automatizar tareas comunes en sistemas Linux.
+
+## Scripts
+
+### `user_management.sh`
+- **Funcionalidad:** sincroniza los usuarios locales con una lista `usernames.txt`: crea cuentas que faltan, genera claves SSH y elimina las que no estén listadas (con excepciones predefinidas).
+- **Precisión:** depende de la presencia de `usernames.txt` en el directorio de trabajo y de utilidades como `useradd`, `ssh-keygen` y `userdel`. La lista de excepciones debe mantenerse actualizada para evitar eliminar cuentas de sistema.
+- **Complejidad:** media.
+- **Manual de uso:**
+  1. Preparar `usernames.txt` con un usuario por línea.
+  2. Ejecutar como root (`sudo ./user_management.sh`).
+  3. Revisar `/var/log/auth.log` o el propio output para validar la creación/eliminación de cuentas.
+
+## Subdirectorios
+
+### `Kali`
+- **Archivos:** `.zshrc` y `.zsh_functions` personalizados para entornos Kali Linux.
+- **Uso:** copiar a `$HOME` del usuario objetivo para aplicar alias y funciones preconfiguradas.
+
+### `OpenLDAP`
+- **Archivo:** `openldap_configure_wizard.sh`.
+  - **Funcionalidad:** asistente interactivo que genera ficheros `usuario.ldif`, `grupos.ldif` y `unidadesorganizativas.ldif` en `$HOME/LDAP`.
+  - **Manual de uso:** ejecutar el script, indicar la cantidad de objetos a crear y responder a los prompts. Importar los `.ldif` resultantes con `ldapadd`.
+
+### `Update_RHEL8.0`
+- **Archivo:** `Actualizar_RHEL8.0`.
+  - **Funcionalidad:** registra un sistema RHEL 8.6 con `subscription-manager`, limpia cachés `yum`, ejecuta `yum update -y` y reinicia.
+  - **Manual de uso:** editar `username` y `password`, ejecutar como root y monitorizar `/var/log/script.log` para validar el proceso.

--- a/Operating_System_Configuration/Linux/Update_RHEL8.0/README.md
+++ b/Operating_System_Configuration/Linux/Update_RHEL8.0/README.md
@@ -1,0 +1,7 @@
+# Update_RHEL8.0
+
+### `Actualizar_RHEL8.0`
+- **Funcionalidad:** registra una suscripción de Red Hat Enterprise Linux 8.6, ejecuta `yum clean all`, aplica todas las actualizaciones disponibles y reinicia el sistema.
+- **Precisión:** guarda la salida en `/var/log/script.log` y detiene la ejecución si `subscription-manager` falla. Las credenciales están codificadas y deben modificarse.
+- **Complejidad:** baja.
+- **Manual de uso:** editar usuario/contraseña al inicio del script, ejecutarlo como root (`bash Actualizar_RHEL8.0`) y revisar el log generado para confirmar que la actualización concluyó correctamente.

--- a/Operating_System_Configuration/Windows/README.md
+++ b/Operating_System_Configuration/Windows/README.md
@@ -1,0 +1,13 @@
+# Windows
+
+Scripts de automatización para sistemas Windows.
+
+## Archivos
+### `rdpsshtunel.ps1`
+- **Funcionalidad:** crea un túnel SSH hacia un bastión, solicitando previamente la IP destino mediante una ventana gráfica (`System.Windows.Forms`). Tras comprobar que el puerto local está abierto, lanza `mstsc.exe` contra `localhost:<puerto>` y cierra el túnel al finalizar.
+- **Precisión:** requiere OpenSSH cliente instalado, claves privadas accesibles y permisos para ejecutar procesos ocultos. Genera puertos aleatorios entre 30000-65535 y valida que el túnel esté activo con `Test-NetConnection`.
+- **Complejidad:** media; combina GUI, procesos y limpieza automática.
+- **Manual de uso:**
+  1. Ajustar las variables `$bastionServer`, `$bastionUsername` y `$privateKeyPath`.
+  2. Ejecutar el script en PowerShell con permisos adecuados (`Set-ExecutionPolicy` si es necesario).
+  3. Introducir la IP del host RDP y esperar a que se abra la sesión de Escritorio Remoto.

--- a/Remote_Access_Tools/SSH/README.md
+++ b/Remote_Access_Tools/SSH/README.md
@@ -1,0 +1,39 @@
+# SSH Tools
+
+Conjunto de scripts y utilidades web para gestionar usuarios, claves y configuraciones SSH.
+
+## Archivos
+
+### `generador_url_share_keys.py`
+- **Funcionalidad:** servidor HTTP seguro que genera URLs temporales para descargar pares de claves (`.key`, `.ppk`). Gestiona tokens con expiración, limpieza automática y permisos estrictos.
+- **Precisión:** requiere Python 3 y dependencias estándar; opcionalmente se integra con `gestionar_usuarios.sh`. Ajustar `PORT` y `BASE_TEMP_DIR` según el entorno.
+- **Complejidad:** alta.
+- **Manual:** ejecutar `python3 generador_url_share_keys.py`, invocar `add_user_download()` desde otros scripts o adaptar para CLI.
+
+### `gestionar_usuarios.sh`
+- **Funcionalidad:** sincroniza cuentas locales basadas en `usernames.txt`, genera claves Ed25519, crea versiones PuTTY (`.ppk`) y soporta banderas `--force` para regenerar claves específicas.
+- **Precisión:** exige ejecutar como root y depende de `puttygen` para los `.ppk` (si no está disponible, lo notifica). Protege usuarios de sistema.
+- **Complejidad:** alta.
+- **Manual:** `sudo ./gestionar_usuarios.sh [-f archivo] [--force usuario|--force-all] [-v]`.
+
+### `sshconfig.sh`
+- **Funcionalidad:** lista las entradas del fichero `~/.ssh/config` coloreadas para rápida referencia.
+- **Precisión:** asume que el archivo existe; funciona tanto para root como para usuarios normales.
+- **Complejidad:** baja.
+- **Manual:** `./sshconfig.sh`.
+
+### `sshconfig_edit.sh`
+- **Funcionalidad:** asistente interactivo para añadir o eliminar hosts en `~/.ssh/config`, valida IPs, permite configurar `ProxyJump` y ofrece copiar claves con `ssh-copy-id`.
+- **Precisión:** asume ruta estándar y claves almacenadas como `~/.ssh/access.key`. No incluye shebang; ejecutar con `bash sshconfig_edit.sh`.
+- **Complejidad:** media.
+- **Manual:** seguir los prompts para agregar (`a`) o eliminar (`r`) hosts.
+
+### `sshdconfig_generator`
+- **Funcionalidad:** generador interactivo de `sshd_config` con descripciones extensas y validaciones. Realiza copia de seguridad del archivo actual y crea `sshd_config.generated`.
+- **Precisión:** requiere permisos de superusuario; guía al operador parámetro por parámetro.
+- **Complejidad:** alta.
+- **Manual:** `sudo ./sshdconfig_generator`, revisar el archivo generado y aplicarlo manualmente antes de reiniciar `sshd`.
+
+### `User-Form.html`
+- **Funcionalidad:** formulario web para recopilar datos de creación de usuarios, validando campos y generando JSON listo para automatizaciones.
+- **Uso:** abrir en un navegador, completar el formulario y copiar el resultado generado.

--- a/Script_Utilities/Bash_Header/README.md
+++ b/Script_Utilities/Bash_Header/README.md
@@ -1,0 +1,10 @@
+# Bash_Header
+
+Generador de cabeceras estándar para scripts Bash.
+
+## Script
+### `createheader.sh`
+- **Funcionalidad:** solicita título, descripción, autor y versión, crea un archivo `.sh` con plantilla (shebang, metadatos, líneas separadoras) y abre el editor seleccionado (Vim, Emacs o Nano) en la línea 12.
+- **Precisión:** asegura que el nombre del archivo sea único, normaliza el título (`lowercase`, guiones bajos) y hace ejecutable el script creado.
+- **Complejidad:** baja.
+- **Manual de uso:** ejecutar `bash createheader.sh`, responder a los prompts y elegir el editor preferido para continuar editando el nuevo script.

--- a/Script_Utilities/Hardening/README.md
+++ b/Script_Utilities/Hardening/README.md
@@ -1,0 +1,32 @@
+# Hardening
+
+Scripts para fortificar servidores expuestos a laboratorios de seguridad.
+
+## Scripts
+
+### `fortify-web-system.sh`
+- **Funcionalidad:** despliega medidas de endurecimiento en un host que aloja aplicaciones web vulnerables. Crea un usuario aislado, aplica límites de recursos, configura `sysctl`, habilita AppArmor/Fail2ban/Auditd, instala IDS básicos y ajusta servicios.
+- **Precisión:** asume Debian/Ubuntu y debe ejecutarse como root. Modifica archivos de sistema (`/etc/security/limits.conf`, `/etc/sysctl.d`, `ufw`, etc.), por lo que conviene revisar cada bloque antes de usarlo en producción.
+- **Complejidad:** alta; consta de múltiples pasos con comprobaciones y logs.
+- **Manual de uso:**
+  1. Revisar todas las secciones para adecuarlas al entorno (nombre de usuario, límites, políticas).
+  2. Ejecutar `sudo ./fortify-web-system.sh` y seguir la salida para detectar posibles errores.
+  3. Reiniciar los servicios indicados y verificar con `auditctl -s`, `ufw status`, etc.
+
+### `configure-firewall.sh`
+- **Funcionalidad:** configura `iptables` para un entorno de pruebas WAF, respaldando reglas anteriores, definiendo políticas estrictas y permitiendo únicamente redes autorizadas.
+- **Precisión:** requiere conocer interfaces (`ens3`, `ens7`), gateways y redes permitidas. Usa `iptables-save/restore`, `netfilter-persistent` y Fail2ban.
+- **Complejidad:** alta.
+- **Manual de uso:**
+  1. Ajustar variables `SSH_ALLOWED_NET`, `WAF_TESTING_NET`, `MANAGEMENT_NET`, etc.
+  2. Ejecutar como root y revisar el backup generado en `/etc/iptables/backups/`.
+  3. Validar conectividad tras aplicar las reglas (`iptables -L -n`).
+
+### `ip-rep-fw.sh`
+- **Funcionalidad:** consume feeds de reputación IP (HTTP/HTTPS), genera reglas para bloquear direcciones maliciosas y mantiene métricas/estadísticas en `/var/log/ip-rep-fw/`.
+- **Precisión:** configurable vía variables de entorno o archivo `.conf`; registra en syslog si se habilita. Requiere `curl`, `jq` y privilegios para manipular `iptables`/`nftables` según la integración deseada.
+- **Complejidad:** alta; implementa logging estructurado, métricas y cachés.
+- **Manual de uso:**
+  1. Configurar `CONF_FILE` o variables (`FEEDS`, `OUTPUT_DIR`, etc.).
+  2. Ejecutar manualmente o programar con cron/systemd timer.
+  3. Revisar los logs y estadísticas generadas para asegurarse de que los feeds se procesan correctamente.

--- a/Script_Utilities/Let's Encrypt/README.md
+++ b/Script_Utilities/Let's Encrypt/README.md
@@ -1,0 +1,7 @@
+# Let's Encrypt
+
+Documentación sobre la emisión manual de certificados comodín para Nginx.
+
+- **Archivo:** `manual_wildcard_certificate_nginx.md`
+  - **Contenido:** guía paso a paso para solicitar certificados comodín con `certbot`, validar desafíos DNS y configurar Nginx.
+  - **Uso:** seguir los pasos descritos y adaptar los comandos a los dominios propios.

--- a/Script_Utilities/README.md
+++ b/Script_Utilities/README.md
@@ -1,22 +1,69 @@
 # Script_Utilities
 
-Miscellaneous helper scripts for everyday administration tasks.
+Colección de utilidades para tareas administrativas diversas.
 
-## Subdirectories
+## Scripts principales
 
-- `Bash_Header` - Utility to generate a standard bash script header.
-- `Restricted_Shell` - Example implementations of a restricted shell.
-- `YouTube` - Python tools for transcribing video or audio.
-- `"Let's Encrypt"` - Notes on obtaining wildcard certificates.
+### `Get-VMInfo.ps1` / `Get-VMInfo.py`
+- **Funcionalidad:** conectan a un servidor vCenter, consultan información detallada de máquinas virtuales (CPU, RAM, datastore, VLAN, snapshots) y permiten ampliar la salida con la opción `-AllData`.
+- **Precisión:** requieren VMware PowerCLI y credenciales válidas. El script `.py` es en realidad PowerShell y debe ejecutarse en un entorno con PowerShell Core.
+- **Complejidad:** media-alta; combinan consultas a múltiples cmdlets y gestión de excepciones.
+- **Manual de uso:** editar usuario/servidor, ejecutar `./Get-VMInfo.ps1 [-AllData] <VM>` o adaptar para listar todas las VMs según las funciones incluidas.
 
-## Other scripts
+### `aviso_reinicio.sh`
+- **Funcionalidad:** envía un aviso de reinicio a todos los usuarios conectados usando `wall`.
+- **Precisión:** mensaje predefinido; modificar el texto según la operación planificada.
+- **Complejidad:** baja.
+- **Manual:** `sudo ./aviso_reinicio.sh`.
 
-- `Get-VMInfo.ps1` and `Get-VMInfo.py` - Gather information about virtual machines.
-- `aviso_reinicio.sh` - Notify users about an upcoming reboot.
-- `compare_directories_details.sh` - Compare two directories in detail.
-- `directory_content_viewer.sh` - Show directory sizes and files.
-- `dns_smart_autotune.py` - Automatically tune DNS resolver settings.
-- `get_os_by_ttl.sh` and `identify_os_advanced.sh` - Detect the OS of a host via TTL analysis.
-- `remove_info_login.sh` - Clean login banners of sensitive info.
-- `scan_space.sh` - Report available disk space.
-- `splitxt.py` - Split text files based on size.
+### `compare_directories_details.sh`
+- **Funcionalidad:** compara dos directorios generando hashes SHA1, muestra diferencias y, opcionalmente, archivos idénticos con detalles de tamaño/fecha.
+- **Precisión:** requiere acceso de lectura a ambos directorios; usa `find`, `sha1sum` y `stat`.
+- **Complejidad:** media.
+- **Manual:** `./compare_directories_details.sh /ruta/origen /ruta/destino` y responder si se desean listar coincidencias.
+
+### `directory_content_viewer.sh`
+- **Funcionalidad:** imprime el contenido de cada archivo en los directorios pasados como argumento con formato resaltado.
+- **Precisión:** no filtra archivos binarios; revisar antes de usar en directorios grandes.
+- **Complejidad:** baja.
+- **Manual:** `./directory_content_viewer.sh /ruta1 /ruta2`.
+
+### `dns_smart_autotune.py`
+- **Funcionalidad:** benchmark de servidores DNS con almacenamiento histórico en SQLite, aprendizaje automático (`RandomForestRegressor`, `IsolationForest`) y generación de métricas (latencia, estabilidad, anomalías).
+- **Precisión:** necesita privilegios de red, dependencias `dnspython`, `numpy`, `scikit-learn`. Los resultados mejoran con ejecuciones sucesivas gracias al modelo persistente.
+- **Complejidad:** alta.
+- **Manual:** `sudo python3 dns_smart_autotune.py [--quick|--duration N|--learning|--reset-learning]`.
+
+### `get_os_by_ttl.sh`
+- **Funcionalidad:** escanea rangos definidos en `networks`, ejecuta pings y clasifica hosts según el TTL para inferir su sistema operativo.
+- **Precisión:** heurística basada en valores comunes de TTL; pueden producirse falsos positivos tras saltos de red.
+- **Complejidad:** media.
+- **Manual:** definir redes dentro del script y ejecutar con flags (`-w`, `-l`, `-o`, `-x`).
+
+### `identify_os_advanced.sh`
+- **Funcionalidad:** identifica distribución Linux, gestor de paquetes, versión de kernel y deduce antigüedad aproximada del sistema. Muestra `uname`, `lsb_release`, `hostnamectl` cuando están disponibles.
+- **Precisión:** depende de archivos `/etc/*release`.
+- **Complejidad:** baja.
+- **Manual:** `./identify_os_advanced.sh`.
+
+### `remove_info_login.sh`
+- **Funcionalidad:** deshabilita el log de último acceso en SSH y silencia MOTD dinámico en Ubuntu.
+- **Precisión:** modifica `/etc/ssh/sshd_config` y permisos en `/etc/update-motd.d`.
+- **Complejidad:** baja.
+- **Manual:** ejecutar como root y reiniciar el servicio SSH.
+
+### `scan_space.sh`
+- **Funcionalidad:** calcula uso de disco de un directorio o de cada subdirectorio inmediato.
+- **Precisión:** requiere ejecutar como root para evitar errores de permisos; ignora enlaces simbólicos.
+- **Complejidad:** baja.
+- **Manual:** `sudo ./scan_space.sh /ruta`.
+
+### `splitxt.py`
+- **Funcionalidad:** divide archivos de texto en bloques de tamaño fijo y crea archivos numerados.
+- **Precisión:** opera en modo texto UTF-8; ideal para dividir grandes ficheros de log.
+- **Complejidad:** baja.
+- **Manual:** `python splitxt.py archivo.txt 40000`.
+
+## Scripts adicionales
+- `directory_content_viewer.sh`, `compare_directories_details.sh`, `dns_smart_autotune.py`, etc., pueden combinarse con las subcarpetas descritas en los READMEs correspondientes.
+- Consulte cada subdirectorio (`Bash_Header`, `Restricted_Shell`, `Hardening`, `YouTube`, `Let's Encrypt`) para utilidades especializadas.

--- a/Script_Utilities/Restricted_Shell/README.md
+++ b/Script_Utilities/Restricted_Shell/README.md
@@ -1,0 +1,19 @@
+# Restricted_Shell
+
+Shells restringidas y herramientas asociadas para limitar comandos de usuarios.
+
+## Scripts
+
+### `restricted_shell`
+- **Funcionalidad:** shell en Bash que limita la ejecución a comandos permitidos (`ping`, `ssh`, `plink`, `telnet`, `tracepath`, `mtr`, `help`, `exit`). Mantiene historial propio, registra cada comando en `/var/log/restricted_shell.log`, valida rutas de salida y bloquea CIDR definidos.
+- **Precisión:** determina la ruta de salida con `ip route get` y la compara con `allowed_routes`. Los bloqueos de red (`restricted_networks`) deben definirse manualmente.
+- **Complejidad:** media-alta; incorpora control de señales, análisis de argumentos, logging y validaciones de IP/CIDR.
+- **Manual de uso:**
+  1. Ajustar listas `allowed_commands`, `allowed_routes` y `restricted_networks` según políticas internas.
+  2. Copiar el script a `/usr/bin/restricted_shell`, otorgar permisos (`chmod 750`) y asignarlo como shell en `/etc/passwd` para los usuarios objetivo.
+  3. Revisar `restricted_shell.log` para auditar comandos.
+
+## Subdirectorios
+
+### `Secure Shell`
+Véase el README del subdirectorio para la implementación en C++ y el script de despliegue.

--- a/Script_Utilities/Restricted_Shell/Secure Shell/README.md
+++ b/Script_Utilities/Restricted_Shell/Secure Shell/README.md
@@ -1,0 +1,19 @@
+# Secure Shell
+
+Implementación en C++ de una shell restringida acompañada de un instalador en Bash.
+
+## Archivos
+
+### `secure_shell.cpp`
+- **Funcionalidad:** shell robusta con control de argumentos, límites de uso para comandos (`ping`, `tracepath`, `ssh`), registro rotativo mediante `spdlog` y aplicación de capacidades POSIX (`cap_net_raw`, `cap_net_admin`). Sanitiza entradas, limita número de argumentos y evita opciones peligrosas en SSH.
+- **Precisión:** depende de bibliotecas Boost, `libcap`, `fmt`, `spdlog` y de MIBs del sistema. Gestiona conexiones simultáneas (`MAX_SSH_CONNECTIONS`) y bloquea intentos fallidos repetidos.
+- **Complejidad:** alta.
+- **Manual de uso:**
+  1. Compilar con el script `setup_secure_shell.sh` o manualmente (`g++ secure_shell.cpp -o /usr/bin/secure_shell ...`).
+  2. Editar el archivo de configuración `/etc/secure_shell.conf` para ajustar límites.
+  3. Asignar la shell a usuarios restringidos.
+
+### `setup_secure_shell.sh`
+- **Funcionalidad:** instala dependencias (compiladores, Boost, libcap, etc.), compila `secure_shell`, crea usuario `secureshell`, prepara un chroot y configura logging.
+- **Precisión:** pensado para Debian/Ubuntu. Ajusta capacidades con `setcap` y crea el archivo de configuración por defecto.
+- **Manual de uso:** ejecutar como root (`sudo ./setup_secure_shell.sh`), revisar el chroot generado y añadir los binarios necesarios dentro de `/home/secureshell/chroot` antes de conceder acceso.

--- a/Script_Utilities/YouTube/README.md
+++ b/Script_Utilities/YouTube/README.md
@@ -1,0 +1,20 @@
+# YouTube
+
+Scripts para descargar transcripciones de videos de YouTube usando la API oficial.
+
+## Scripts
+
+### `stream_transcription.py`
+- **Funcionalidad:** identifica transmisiones en vivo finalizadas de un canal y descarga transcripciones en el idioma indicado.
+- **Precisión:** requiere API key de Google y gestiona excepciones `TranscriptsDisabled`/`NoTranscriptFound`. Usa `youtube_transcript_api` y la API Data v3.
+- **Complejidad:** media.
+- **Manual de uso:**
+  1. Instalar dependencias (`pip install google-api-python-client youtube-transcript-api`).
+  2. Configurar `API_KEY`, `CHANNEL_ID`, `SAVE_DIR` y ejecutar el script.
+  3. Las transcripciones se guardan como `<título>_<lang>.txt`.
+
+### `video_transcription.py`
+- **Funcionalidad:** recorre videos subidos de un canal, limpia títulos para uso como nombre de archivo y guarda transcripciones.
+- **Precisión:** mismo manejo de errores que el script anterior.
+- **Complejidad:** media.
+- **Manual de uso:** igual que el script de streams pero aplicable a videos publicados.

--- a/Service_Configurations/Audit/README.md
+++ b/Service_Configurations/Audit/README.md
@@ -1,0 +1,22 @@
+# Audit
+
+Recursos para configurar `auditd`.
+
+## Archivos
+
+### `audit.rules`
+- **Funcionalidad:** conjunto extensivo de reglas recomendadas (basadas en guías Gov.uk, PCI, NISPOM). Limpia reglas previas, establece buffers, filtros y audita actividades críticas (kernel, módulos, cron, cuentas, cambios de permisos, etc.).
+- **Precisión:** compatible con auditd 2.8+/Linux kernel 4+. Algunas reglas hacen referencia a arquitecturas `b64`; conviene revisar syscalls disponibles si se usa ARM o plataformas sin `open`. Incluye exclusiones para reducir ruido.
+- **Complejidad:** alta; cubre decenas de categorías y requiere comprender el impacto en el rendimiento.
+- **Manual de uso:**
+  1. Respaldar `/etc/audit/rules.d` y `/etc/audit/audit.rules` actuales.
+  2. Copiar el archivo como `/etc/audit/audit.rules` o dividirlo en `rules.d/`.
+  3. Ejecutar `augenrules --load` o reiniciar `auditd`.
+  4. Monitorizar `/var/log/audit/audit.log` para ajustar filtros según el entorno.
+
+## Directorios
+
+### `rules/`
+- **Contenido:** colecciones modulares agrupadas por prefijo (10-, 20-, 30-, etc.) para usarse con `augenrules`. Incluyen perfiles PCI DSS, STIG, OSPP y reglas locales.
+- **Uso:** copiar sólo los archivos relevantes a `/etc/audit/rules.d/` según el perfil deseado, regenerar con `augenrules --load` y reiniciar `auditd`.
+- **Documentación:** revisar `README-rules` para entender el orden de carga y cómo regenerar `31-privileged.rules`.

--- a/Service_Configurations/Audit/rules/README.md
+++ b/Service_Configurations/Audit/rules/README.md
@@ -1,0 +1,19 @@
+# rules
+
+Colección oficial de reglas de `auditd` organizadas para `augenrules`.
+
+## Organización por prefijo
+- **10-** Configuración base del demonio (buffers, política de fallo, loginuid).
+- **20-** Exclusiones o filtros que evitan duplicidades con reglas específicas.
+- **30-** Perfiles completos (OSPP, PCI DSS, STIG) divididos por tipo de evento (creación, modificación, permisos, etc.).
+- **31-** Reglas generadas dinámicamente para binarios con privilegios (ver comentarios en `31-privileged.rules`).
+- **40/41/42/43/44-** Reglas opcionales: personalización local, contenedores, detección de inyección, carga de módulos, instalación de software.
+- **70-** Manejo de errores `EINVAL`.
+- **71-** Eventos de red.
+- **99-** Clausura (`-e 2`) para inmovilizar la política.
+
+## Manual de uso
+1. Seleccionar los archivos que representen el perfil de cumplimiento deseado.
+2. Copiarlos a `/etc/audit/rules.d/` manteniendo el prefijo numérico.
+3. Regenerar la política (`augenrules --load`).
+4. Verificar con `auditctl -l` que las reglas estén activas y ajustar según el volumen de eventos.

--- a/Service_Configurations/Monitoring/Nagios/README.md
+++ b/Service_Configurations/Monitoring/Nagios/README.md
@@ -1,0 +1,49 @@
+# Nagios
+
+Este árbol reúne asistentes para automatizar la incorporación de hosts y los conjuntos de configuración base empleados por Nagios Core.
+
+## Scripts
+
+### `add_host_csv.sh`
+- **Funcionalidad:** importa hosts desde un `hosts.csv`, genera definiciones `define host` y `define service` y mantiene actualizadas las pertenencias a `hostgroups` dentro del fichero principal de objetos.
+- **Precisión y alcance:** confía en la existencia del CSV y en nombres de grupos válidos. Usa `awk` y copias temporales para evitar corrupción, pero no valida que los comandos o plantillas existan en el runtime de Nagios.
+- **Complejidad:** media; automatiza la edición de archivos de configuración, detecta el separador del CSV y actualiza hostgroups de forma incremental.
+- **Manual de uso:**
+  1. Ajustar la variable `NAGIOS_CONFIG` con la ruta al archivo `.cfg` destino.
+  2. Preparar `hosts.csv` con columnas `host_name,alias,address,hostgroup` y ejecutar `bash add_host_csv.sh`.
+  3. Verificar el archivo actualizado y reiniciar Nagios (`nagios -v ...` y `systemctl restart nagios`).
+
+### `add_host_wizard.sh`
+- **Funcionalidad:** asistente interactivo que permite crear un fichero de cliente nuevo o reutilizar uno existente, añadir múltiples hosts y anexa servicios base (PING). Gestiona la membresía de hostgroups.
+- **Precisión y alcance:** usa `select` y confirmaciones para evitar errores de entrada. No valida direcciones IP ni elimina duplicados; se recomienda revisión manual antes de recargar Nagios.
+- **Complejidad:** media-baja; combina bucles y `awk` para actualizar hostgroups.
+- **Manual de uso:**
+  1. Ejecutar como usuario con permisos sobre `/usr/local/nagios/etc`.
+  2. Elegir si se creará un cliente nuevo o se editará uno existente.
+  3. Indicar cuántos hosts se añadirán y proporcionar sus campos.
+  4. Seleccionar o crear el hostgroup objetivo.
+  5. Validar con `nagios -v` y reiniciar el servicio.
+
+### `install_ndoutils.sh`
+- **Funcionalidad:** instala MySQL y NDOUtils 2.1.3, crea la base de datos `nagios`, genera el usuario `ndoutils` y activa el broker `ndomod.o`.
+- **Precisión y alcance:** pensado para Ubuntu/Debian. Usa credenciales codificadas en el script y no endurece MySQL; se recomienda cambiarlas tras la ejecución.
+- **Complejidad:** media; automatiza descarga, compilación y ajustes mínimos.
+- **Manual de uso:**
+  1. Ejecutar como root en el servidor Nagios.
+  2. Esperar a que instale dependencias y compile.
+  3. Revisar `/usr/local/nagios/etc/ndo2db.cfg` para ajustar credenciales.
+  4. Reiniciar Nagios y comprobar que `ndo2db` está activo.
+
+### `nagios configuration file`
+- **Funcionalidad:** plantilla del archivo `nagios.cfg` con opciones de logging, rutas y parámetros de ejecución predeterminados.
+- **Uso recomendado:** copiar a `/usr/local/nagios/etc/nagios.cfg` y ajustar rutas (`cfg_file`, `cfg_dir`, etc.) para el entorno específico.
+
+## Configuraciones
+
+### `Templates/`
+- Contiene definiciones base (`generic-host`, `generic-service`, `contactgroups`, `timeperiods`, etc.) listas para importarse. Útiles como punto de partida para nuevos despliegues o para mantener convenciones homogéneas.
+
+### `sample-config/`
+- Incluye los archivos `*.cfg.in` originales del paquete Nagios (HTTPD, MRTG, `nagios.cfg`, plantillas de objetos). Sirven como referencia para regenerar configuraciones o estudiar los parámetros por defecto.
+  - `template-object/` aporta ejemplos para `localhost`, impresoras, switches, hosts Windows y los comandos asociados.
+  - Revisar los archivos README adjuntos para instrucciones de `augenrules` y compilación de plantillas.

--- a/Service_Configurations/Monitoring/Nagios/Templates/README.md
+++ b/Service_Configurations/Monitoring/Nagios/Templates/README.md
@@ -1,0 +1,14 @@
+# Templates
+
+Plantillas de objetos para Nagios Core.
+
+## Archivos
+- `commands.cfg`: define comandos comunes (`check_ping`, `check_ssh`, etc.) que sirven de base a los servicios añadidos por los asistentes.
+- `contacts.cfg`, `contactgroups.cfg`: estructura de contactos, pensada para usarse como ejemplo y adaptarse con los usuarios reales.
+- `generic-host.cfg`, `generic-service.cfg`, `generic-switch.cfg`: plantillas con parámetros por defecto que minimizan la repetición en las definiciones.
+- `timeperiods.cfg`: ventanas de notificación/monitorización predefinidas.
+
+## Uso sugerido
+1. Copiar los ficheros a `objects/` dentro del árbol de Nagios.
+2. Ajustar nombres de contactos, emails, escalados y comandos según la organización.
+3. Ejecutar `nagios -v /ruta/nagios.cfg` para validar la sintaxis antes de recargar el servicio.

--- a/Service_Configurations/Monitoring/Nagios/sample-config/README.md
+++ b/Service_Configurations/Monitoring/Nagios/sample-config/README.md
@@ -1,0 +1,15 @@
+# sample-config
+
+Archivos de configuración de referencia distribuidos con Nagios.
+
+## Archivos principales
+- `cgi.cfg.in`, `nagios.cfg.in`, `resource.cfg.in`, `mrtg.cfg.in`, `httpd.conf.in`: plantillas oficiales con comentarios que explican cada parámetro del demonio, la interfaz CGI y servicios auxiliares.
+- `README`: instrucciones de uso y relación con el sistema de construcción original.
+
+## Subdirectorios
+- `template-object/`: definiciones `*.cfg.in` para hosts y comandos de ejemplo (localhost, impresoras, Windows, switches). Resultan útiles como punto de partida para generar archivos propios con `make` o para copiar bloques concretos.
+
+## Uso sugerido
+1. Copiar los archivos necesarios a `/usr/local/nagios/etc` y eliminar la extensión `.in` tras personalizarlos.
+2. Revisar rutas y credenciales antes de habilitar las CGIs o integraciones.
+3. Validar la configuración ejecutando `nagios -v` antes de iniciar o reiniciar el servicio.

--- a/Service_Configurations/Monitoring/Nagios/sample-config/template-object/README.md
+++ b/Service_Configurations/Monitoring/Nagios/sample-config/template-object/README.md
@@ -1,0 +1,15 @@
+# template-object
+
+Colección de objetos de ejemplo que acompañan al paquete Nagios original.
+
+## Contenido destacado
+- `localhost.cfg.in`: servicios estándar para el servidor local (carga, uso de disco, procesos críticos).
+- `switch.cfg.in`, `printer.cfg.in`: ejemplos de dispositivos de red/impresoras con plantillas de chequeo SNMP.
+- `windows.cfg.in`: definiciones base para hosts Windows usando `check_nt`.
+- `commands.cfg.in`, `templates.cfg.in`, `timeperiods.cfg.in`: comandos y plantillas reutilizables.
+- `contacts.cfg.in`: contactos y grupos predefinidos.
+
+## Uso sugerido
+1. Eliminar la extensión `.in` y ajustar los valores (hostnames, comunidades SNMP, contraseñas) antes de copiarlos a `objects/`.
+2. Integrar solo los bloques necesarios para evitar duplicidades con plantillas personalizadas.
+3. Validar con `nagios -v` tras importar los objetos.

--- a/Service_Configurations/Monitoring/README.md
+++ b/Service_Configurations/Monitoring/README.md
@@ -1,0 +1,6 @@
+# Monitoring
+
+Colección de configuraciones y asistentes pensados para desplegar y mantener instancias de Nagios.
+
+## Contenido
+- `Nagios/` agrupa asistentes en Bash y árboles de configuración de ejemplo. Cada subdirectorio incluye su propio README con detalles prácticos.

--- a/Service_Configurations/SSH/README.md
+++ b/Service_Configurations/SSH/README.md
@@ -1,0 +1,11 @@
+# SSH
+
+Ejemplo completo de `sshd_config` con la mayoría de las directivas disponibles comentadas.
+
+- **Funcionalidad:** sirve como referencia para endurecer o habilitar características de OpenSSH. Incluye ejemplos de `AcceptEnv`, listas de usuarios/grupos permitidos o denegados, banners, opciones de GSSAPI, CAs, algoritmos y controles de forwarding.
+- **Precisión:** los valores responden a la sintaxis oficial de OpenSSH 8.x. No se aplican validaciones automáticas; al copiarlo conviene revisar que las rutas (por ejemplo `/usr/local/sbin/lookup-ssh-keys`) existan en el sistema.
+- **Complejidad:** baja-media; es un fichero declarativo extenso sin lógica, pero cubre ajustes avanzados.
+- **Manual de uso:**
+  1. Copiar el archivo a `/etc/ssh/sshd_config` o integrarlo parcialmente.
+  2. Sustituir usuarios, grupos, rutas y algoritmos según la política interna.
+  3. Ejecutar `sshd -t` para validar la sintaxis y reiniciar el servicio (`systemctl restart sshd`).

--- a/Service_Configurations/Sample_Init_Service/README.md
+++ b/Service_Configurations/Sample_Init_Service/README.md
@@ -1,0 +1,13 @@
+# Sample Init Service
+
+Plantilla de script `init.d` para servicios clásicos en Debian/Ubuntu.
+
+- **Archivo:** `Sample init.d file service`
+  - **Funcionalidad:** usa `start-stop-daemon` para lanzar un demonio PHP en segundo plano, gestionar el PID y registrar la salida en `/var/log/<nombre>.log`.
+  - **Precisión:** respeta la cabecera `INIT INFO` para integrarse con `update-rc.d`. Las rutas (`/usr/bin/php`, `/var/www/myproject/myscript.php`) son ejemplos y deben ajustarse.
+  - **Complejidad:** baja; proporciona las funciones básicas `start`, `stop`, `restart` con manejo de PID y limpieza.
+  - **Manual de uso:**
+    1. Copiar el fichero a `/etc/init.d/<nombre>` y ajustar `NAME`, `DESC`, `DAEMON` y `DAEMON_OPTS`.
+    2. Dar permisos de ejecución (`chmod +x`).
+    3. Registrar el servicio (`update-rc.d <nombre> defaults`).
+    4. Gestionar con `service <nombre> start|stop|restart`.

--- a/System_Installers/Grafana Telegraf InfluxDB 2.7 - Docker/README.md
+++ b/System_Installers/Grafana Telegraf InfluxDB 2.7 - Docker/README.md
@@ -1,1 +1,19 @@
+# Grafana Telegraf InfluxDB 2.7 - Docker
 
+Stack Docker Compose para monitorización de red con InfluxDB 2.7, Telegraf y Grafana.
+
+## Archivos
+- `docker-compose.yml`
+  - **Funcionalidad:** define tres servicios (`influxdb`, `telegraf`, `grafana`) conectados en la red `network_monitoring`. Expone los puertos 8086 y 3000, incluye `healthcheck` para InfluxDB y monta volúmenes persistentes.
+  - **Precisión:** requiere variables de entorno (`INFLUXDB_USERNAME`, `INFLUXDB_PASSWORD`, etc.) definidas en un `.env`. Asume Docker 20.10+.
+  - **Complejidad:** media; orquesta dependencias y volúmenes.
+  - **Manual de uso:**
+    1. Crear un archivo `.env` con credenciales y tokens.
+    2. Revisar las carpetas `influxdb/`, `telegraf/` y `grafana/` para personalizar configuraciones.
+    3. Ejecutar `docker compose up -d` desde el directorio.
+    4. Verificar la salud de los contenedores (`docker compose ps`).
+
+## Subdirectorios
+- `influxdb/`: configuración y almacenamiento de InfluxDB.
+- `telegraf/`: configuración del agente de métricas.
+- `grafana/`: datos y configuración del dashboard.

--- a/System_Installers/Grafana Telegraf InfluxDB 2.7 - Docker/grafana/README.md
+++ b/System_Installers/Grafana Telegraf InfluxDB 2.7 - Docker/grafana/README.md
@@ -1,0 +1,13 @@
+# grafana
+
+Configuración y almacenamiento de Grafana dentro del stack Docker.
+
+## Archivos
+### `grafana.ini`
+- **Funcionalidad:** versión mínima que delega credenciales al entorno (`GF_SECURITY_ADMIN_USER` y `GF_SECURITY_ADMIN_PASSWORD`). Adecuada para pruebas o entornos pequeños.
+- **Uso:** se monta en `/etc/grafana/grafana.ini` del contenedor. Ajustar el dominio y las opciones de registro según el despliegue.
+
+### `config/grafana.ini`
+- **Funcionalidad:** configuración avanzada orientada a un entorno profesional (rotación de logs, seguridad endurecida, opciones de snapshot y dashboards).
+- **Precisión:** valores de ejemplo (usuario `netadmin`, contraseñas y claves secretas) deben sustituirse antes de producción.
+- **Manual de uso:** copiar al directorio `config/` del contenedor y actualizar rutas, políticas de seguridad y credenciales.

--- a/System_Installers/Grafana Telegraf InfluxDB 2.7 - Docker/grafana/config/README.md
+++ b/System_Installers/Grafana Telegraf InfluxDB 2.7 - Docker/grafana/config/README.md
@@ -1,0 +1,7 @@
+# config
+
+Configuraciones extendidas de Grafana.
+
+- `grafana.ini`: fichero detallado con parámetros de seguridad, rutas, políticas de usuarios y opciones de snapshot. Úsalo cuando se requiera un control granular.
+
+**Manual:** Copiar sobre `/etc/grafana/grafana.ini` dentro del contenedor y adaptar credenciales, claves y URLs antes de poner en producción.

--- a/System_Installers/Grafana Telegraf InfluxDB 2.7 - Docker/influxdb/README.md
+++ b/System_Installers/Grafana Telegraf InfluxDB 2.7 - Docker/influxdb/README.md
@@ -1,0 +1,7 @@
+# influxdb
+
+Directorio de datos y configuraciones para InfluxDB 2.x dentro del stack Docker.
+
+## Subdirectorios
+- `config/`: archivos que se montan en `/etc/influxdb2`.
+- `data/`: volumen persistente creado automáticamente por Docker para almacenar metadatos y series temporales.

--- a/System_Installers/Grafana Telegraf InfluxDB 2.7 - Docker/influxdb/config/README.md
+++ b/System_Installers/Grafana Telegraf InfluxDB 2.7 - Docker/influxdb/config/README.md
@@ -1,0 +1,8 @@
+# config
+
+Configuración CLI de InfluxDB.
+
+### `influx-configs`
+- **Funcionalidad:** fichero compatible con `influx config` que define un perfil por defecto (`network-monitoring-token-secure-2024`).
+- **Uso:** copiar a `/etc/influxdb2/influx-configs` para que la CLI tenga credenciales y URL preconfiguradas.
+- **Precisión:** sustituir token y URL por valores reales antes de arrancar el contenedor en producción.

--- a/System_Installers/Grafana Telegraf InfluxDB 2.7 - Docker/telegraf/README.md
+++ b/System_Installers/Grafana Telegraf InfluxDB 2.7 - Docker/telegraf/README.md
@@ -1,0 +1,13 @@
+# telegraf
+
+Configuración del agente Telegraf empleado por el stack Docker.
+
+## Archivos
+### `telegraf.conf`
+- **Funcionalidad:** configura el agente con intervalo de 30s, jitter para distribución de carga y salida hacia InfluxDB v2 mediante token (`INFLUX_TOKEN`). Establece `hostname` estático para diferenciar métricas.
+- **Precisión:** ajustado para enviar datos al servicio `influxdb` del mismo compose. Los valores de `organization` y `bucket` deben coincidir con los definidos en el `.env`.
+- **Complejidad:** baja-media; se limita a configuración global y destino InfluxDB.
+- **Manual de uso:**
+  1. Revisar intervalos y buffers según el volumen de métricas.
+  2. Configurar entradas (plugins `[[inputs.*]]`) adicionales según sea necesario.
+  3. Asegurarse de que la variable `INFLUX_TOKEN` esté disponible como variable de entorno del contenedor.

--- a/System_Installers/TIG/Grafana_Customize/trc_files/README.md
+++ b/System_Installers/TIG/Grafana_Customize/trc_files/README.md
@@ -1,0 +1,9 @@
+# trc_files
+
+Recursos gráficos utilizados por `customizar_grafana.sh`.
+
+- `logo_trc.svg`: logo SVG que reemplaza los íconos por defecto de Grafana.
+- `favicon.ico`: favicon personalizado para la pestaña del navegador.
+- `fondo.png`: imagen de fondo que se aplica a la pantalla de inicio de sesión.
+
+**Uso:** Copiar estos archivos al directorio `trc_files/` del servidor Grafana y ejecutar el script de personalización. Pueden sustituirse por versiones propias manteniendo el mismo nombre y formato.

--- a/Telemetry_Configurations/Telegraf/README.md
+++ b/Telemetry_Configurations/Telegraf/README.md
@@ -1,0 +1,42 @@
+# Telegraf
+
+Herramientas de automatización para generar configuraciones de Telegraf en entornos de monitorización.
+
+## Scripts
+
+### `telegraf_http_icmp_manager.py`
+- **Funcionalidad:** administra ficheros `http_monitoring.conf` e `icmp_monitoring.conf` para un despliegue Docker. Normaliza URLs, resuelve dominios a IPs, crea bloques de entrada y ajusta permisos dentro del contenedor.
+- **Precisión:** valida sintaxis de URLs/IP, detecta configuraciones existentes y evita duplicados. Requiere acceso al socket Docker para ejecutar `docker exec` cuando es necesario recargar Telegraf.
+- **Complejidad:** alta; maneja logging estructurado, prompts interactivos, gestión de permisos y sincronización con contenedores.
+- **Manual de uso:**
+  1. Instalar dependencias (`python3 -m pip install -r requirements.txt` si aplica).
+  2. Ejecutar `python3 telegraf_http_icmp_manager.py --help` para ver las opciones (añadir, eliminar, listar).
+  3. Introducir las URLs a monitorizar; el script genera tanto la comprobación HTTP como el ping a la IP resuelta.
+  4. Recargar el servicio Telegraf al finalizar.
+
+### `telegraf_snmp_agent_basic_manager.py`
+- **Funcionalidad:** asistente sencillo para crear archivos de entrada SNMP basados en una plantilla TOML. Detecta sedes en `/etc/telegraf/telegraf.d`, valida IPs y obtiene el hostname mediante SNMP `get`.
+- **Precisión:** utiliza comunidad `public` para descubrir nombres; se recomienda editarla según el entorno. No gestiona permisos especiales.
+- **Complejidad:** media.
+- **Manual de uso:**
+  1. Ejecutar `python3 telegraf_snmp_agent_basic_manager.py` y seguir el menú interactivo.
+  2. Seleccionar la sede, introducir la IP y confirmar la creación del archivo.
+  3. Revisar el fichero generado y recargar Telegraf.
+
+### `telegraf_snmp_full_manager.py`
+- **Funcionalidad:** versión avanzada con logging configurable, soporte de archivos INI, sanitización de nombres, gestión de permisos (`chown` al usuario `telegraf`) y utilidades para consultar MIBs vía `pysnmp`.
+- **Precisión:** requiere dependencias `psutil` y `pysnmp`, además de que el usuario `telegraf` exista. Permite personalizar comunidad, tiempo de sondeo y si se incluye la IP en el alias.
+- **Complejidad:** alta; incorpora detección de procesos, validaciones múltiples y manejo de señales.
+- **Manual de uso:**
+  1. Crear un archivo de configuración opcional (`/etc/telegraf/manager.ini`) para ajustar parámetros.
+  2. Ejecutar `python3 telegraf_snmp_full_manager.py add --ip <IP>` (consultar `--help` para subcomandos disponibles).
+  3. Confirmar los datos detectados y permitir que el script cree los ficheros bajo `telegraf.d/` con permisos correctos.
+
+### `telegraf_snmp_config_generator.py`
+- **Funcionalidad:** genera configuraciones SNMP masivas a partir de CSV o datos estructurados, soporta plantillas múltiples y utiliza `pysnmp` para validar conectividad.
+- **Precisión:** valida direcciones IP, nombres y tipos de dispositivo; escribe archivos por sede/cliente.
+- **Complejidad:** media-alta, pensada para operaciones batch.
+- **Manual de uso:**
+  1. Preparar la fuente de datos (CSV o parámetros CLI según las opciones disponibles con `--help`).
+  2. Ejecutar el script y revisar los archivos producidos en el directorio destino.
+  3. Recargar o reiniciar Telegraf para aplicar los cambios.


### PR DESCRIPTION
## Summary
- document each script directory with functionality, reliability notes, complexity, and usage instructions
- add READMEs for service configurations, deployment stacks, operating system utilities, telemetry tools, and remote access helpers
- enhance existing references so maintainers can understand and operate every script quickly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6efdd381c8320ad8e09726681fa5a